### PR TITLE
Add real-time Bolt tracker backend and UI

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import math
+import os
+import time
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, List, Optional
+
+import requests
+from flask import Flask, jsonify, request, send_from_directory
+from flask_cors import CORS
+
+
+def create_app() -> Flask:
+    app = Flask(__name__, static_folder="../static", static_url_path="")
+    CORS(app)
+
+    bolt_token = os.environ.get("BOLT_AUTH_TOKEN")
+
+    @dataclass
+    class Vehicle:
+        id: str
+        lat: float
+        lng: float
+        bearing: float
+        category_id: str
+        category_name: str
+        icon_url: Optional[str]
+
+    CATEGORY_CONFIG: Dict[str, Dict[str, Any]] = {
+        "13591": {"name": "Send Motorbike", "color": "#34D399", "emoji": "🟢"},
+        "13592": {"name": "XL", "color": "#60A5FA", "emoji": "🔵"},
+        "13593": {"name": "Bolt", "color": "#A855F7", "emoji": "🟣"},
+        "13595": {"name": "Motorbike", "color": "#FBBF24", "emoji": "🟡"},
+        "13596": {"name": "City Ride", "color": "#F97316", "emoji": "🟠"},
+    }
+
+    FALLBACK_VEHICLES: List[Vehicle] = [
+        Vehicle("1660285396", 18.772542, 98.979779, 278.77, "13591", "Send Motorbike", None),
+        Vehicle("1660285397", 18.768400, 98.982120, 102.10, "13593", "Bolt", None),
+        Vehicle("1660285398", 18.761230, 98.995430, 45.00, "13596", "City Ride", None),
+        Vehicle("1660285399", 18.749310, 98.986540, 310.20, "13592", "XL", None),
+        Vehicle("1660285400", 18.755120, 98.999900, 210.40, "13595", "Motorbike", None),
+    ]
+
+    def haversine_distance(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
+        radius_km = 6371
+        d_lat = math.radians(lat2 - lat1)
+        d_lng = math.radians(lng2 - lng1)
+        a = math.sin(d_lat / 2) ** 2 + math.cos(math.radians(lat1)) * math.cos(
+            math.radians(lat2)
+        ) * math.sin(d_lng / 2) ** 2
+        c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+        return radius_km * c
+
+    def fetch_from_bolt(lat: float, lng: float, address: str, place_id: str) -> List[Vehicle]:
+        if not bolt_token:
+            return []
+
+        base_url = "https://user.live.boltsvc.net/mobility/search/poll"
+        params = {
+            "version": "CA.180.0",
+            "deviceId": "ffac2e78-84c8-403d-b34e-8394499d7c29",
+            "locale": "en-TH",
+            "gps_lat": str(lat),
+            "gps_lng": str(lng),
+        }
+        headers = {
+            "Authorization": f"Bearer {bolt_token}",
+            "Content-Type": "application/json",
+        }
+        body = {
+            "destination_stops": [],
+            "payment_method": {"id": "cash", "type": "default"},
+            "pickup_stop": {
+                "lat": lat,
+                "lng": lng,
+                "address": address,
+                "place_id": place_id,
+            },
+            "stage": "overview",
+            "viewport": {
+                "north_east": {"lat": lat + 0.02, "lng": lng + 0.02},
+                "south_west": {"lat": lat - 0.02, "lng": lng - 0.02},
+            },
+        }
+        response = requests.post(base_url, params=params, headers=headers, json=body, timeout=6)
+        response.raise_for_status()
+        payload = response.json()
+
+        vehicles: List[Vehicle] = []
+        vehicles_data: Dict[str, Any] = payload.get("vehicles", {})
+        category_details: Dict[str, Any] = payload.get("category_details", {})
+
+        for service_name, service_categories in vehicles_data.items():
+            details_by_category = category_details.get(service_name, {})
+            for category_id, items in service_categories.items():
+                for item in items:
+                    details = details_by_category.get(category_id, {})
+                    vehicles.append(
+                        Vehicle(
+                            id=str(item.get("id")),
+                            lat=float(item.get("lat", lat)),
+                            lng=float(item.get("lng", lng)),
+                            bearing=float(item.get("bearing", 0.0)),
+                            category_id=str(category_id),
+                            category_name=details.get(
+                                "name",
+                                CATEGORY_CONFIG.get(category_id, {}).get("name", "Unknown"),
+                            ),
+                            icon_url=item.get("icon_url"),
+                        )
+                    )
+        return vehicles
+
+    @app.route("/")
+    def index() -> Any:
+        return send_from_directory(app.static_folder, "index.html")
+
+    @app.route("/api/vehicles", methods=["POST"])
+    def get_vehicles() -> Any:
+        body = request.get_json(force=True) if request.data else {}
+        lat = float(body.get("lat", 18.756651))
+        lng = float(body.get("lng", 98.994667))
+        address = body.get("address", "135 ซอย หมู่บ้านในฝัน")
+        place_id = body.get("place_id", "google|ChIJwSgfJj4w2jAR_72NE5V00bA")
+
+        try:
+            vehicles = fetch_from_bolt(lat, lng, address, place_id)
+        except Exception:
+            vehicles = []
+
+        if not vehicles:
+            vehicles = FALLBACK_VEHICLES
+
+        enriched: List[Dict[str, Any]] = []
+        category_counts: Dict[str, int] = {}
+        nearest_vehicle: Optional[Dict[str, Any]] = None
+        min_distance = float("inf")
+
+        for vehicle in vehicles:
+            distance_km = haversine_distance(lat, lng, vehicle.lat, vehicle.lng)
+            record = {
+                **asdict(vehicle),
+                "distance_km": distance_km,
+                "color": CATEGORY_CONFIG.get(vehicle.category_id, {}).get("color", "#FFFFFF"),
+                "emoji": CATEGORY_CONFIG.get(vehicle.category_id, {}).get("emoji", "🚗"),
+            }
+            enriched.append(record)
+            category_counts[vehicle.category_id] = category_counts.get(vehicle.category_id, 0) + 1
+
+            if distance_km < min_distance:
+                min_distance = distance_km
+                nearest_vehicle = record
+
+        categories: List[Dict[str, Any]] = []
+        for category_id, config in CATEGORY_CONFIG.items():
+            categories.append(
+                {
+                    "id": category_id,
+                    "name": config["name"],
+                    "color": config["color"],
+                    "emoji": config["emoji"],
+                    "count": category_counts.get(category_id, 0),
+                }
+            )
+
+        response_payload = {
+            "vehicles": enriched,
+            "categories": categories,
+            "stats": {
+                "total": len(enriched),
+                "nearest": nearest_vehicle,
+                "last_update": time.strftime("%Y-%m-%d %H:%M:%S"),
+            },
+        }
+        return jsonify(response_payload)
+
+    return app
+
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/backend/app.py
+++ b/backend/app.py
@@ -15,7 +15,13 @@ def create_app() -> Flask:
     app = Flask(__name__, static_folder="../static", static_url_path="")
     CORS(app)
 
-    bolt_token = os.environ.get("BOLT_AUTH_TOKEN")
+    bolt_token = os.environ.get(
+        "BOLT_TOKEN",
+        os.environ.get(
+            "BOLT_AUTH_TOKEN",
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkYXRhIjp7InVzZXJfaWQiOjI4MzYxNzQ5NSwidXNlcl9sb2dpbl9pZCI6NjAzNzMzNTg3fSwiaWF0IjoxNzU5NTEwNTg3LCJleHAiOjE3NTk1MTQxODd9.TuM29RFnJGWxmrpwPQVKaO_gu1t9bS6mNBv_Q9zK0-U",
+        ),
+    )
 
     @dataclass
     class Vehicle:
@@ -61,14 +67,33 @@ def create_app() -> Flask:
         params = {
             "version": "CA.180.0",
             "deviceId": "ffac2e78-84c8-403d-b34e-8394499d7c29",
-            "locale": "en-TH",
-            "gps_lat": str(lat),
-            "gps_lng": str(lng),
+            "device_name": "XiaomiMi 11 Lite 4G",
+            "device_os_version": "12",
+            "channel": "googleplay",
+            "brand": "bolt",
+            "deviceType": "android",
+            "signup_session_id": "",
+            "country": "th",
+            "is_local_authentication_available": "false",
+            "language": "th",
+            "gps_lat": f"{lat:.6f}",
+            "gps_lng": f"{lng:.6f}",
+            "gps_accuracy_m": "10.0",
+            "gps_age": "0",
+            "user_id": "283617495",
+            "session_id": "283617495u1759509459582",
+            "distinct_id": "client-283617495",
+            "rh_session_id": "283617495u1759509267",
         }
         headers = {
+            "Host": "user.live.boltsvc.net",
             "Authorization": f"Bearer {bolt_token}",
-            "Content-Type": "application/json",
+            "Content-Type": "application/json; charset=UTF-8",
+            "Accept-Encoding": "gzip, deflate, br",
+            "User-Agent": "okhttp/4.12.0",
         }
+        viewport_padding_lat = 0.02070900924817
+        viewport_padding_lng = 0.02647531139420637
         body = {
             "destination_stops": [],
             "payment_method": {"id": "cash", "type": "default"},
@@ -80,8 +105,14 @@ def create_app() -> Flask:
             },
             "stage": "overview",
             "viewport": {
-                "north_east": {"lat": lat + 0.02, "lng": lng + 0.02},
-                "south_west": {"lat": lat - 0.02, "lng": lng - 0.02},
+                "north_east": {
+                    "lat": lat + viewport_padding_lat,
+                    "lng": lng + viewport_padding_lng,
+                },
+                "south_west": {
+                    "lat": lat - viewport_padding_lat,
+                    "lng": lng - viewport_padding_lng,
+                },
             },
         }
         response = requests.post(base_url, params=params, headers=headers, json=body, timeout=6)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask==3.0.3
+flask-cors==4.0.1
+requests==2.32.3

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full bg-gray-900 text-slate-100">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bolt Real-time Vehicle Tracker</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+          integrity="sha256-Vz6HtRrC8XkGhlkZ6kPvxI6TkfQZvF59a+I1B9Jk0LM=" crossorigin="" />
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+            integrity="sha256-o9N1j7kP4G9TnppZArYdS9x+h0cYf9j/dVt0gYw0XDY=" crossorigin=""></script>
+    <link rel="stylesheet" href="styles.css" />
+</head>
+<body class="h-full font-[Inter]">
+    <div class="min-h-screen flex flex-col">
+        <header class="border-b border-slate-700 bg-slate-900/80 backdrop-blur px-6 py-4">
+            <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <h1 class="text-2xl font-semibold text-emerald-400">🚗 Bolt Real-time Tracker</h1>
+                    <p class="text-sm text-slate-300">ติดตามตำแหน่งรถ Bolt ในเชียงใหม่แบบสด</p>
+                </div>
+                <div class="flex items-center gap-4 text-sm" id="status-bar">
+                    <div class="flex items-center gap-2">
+                        <span class="h-2 w-2 rounded-full bg-red-400" id="connection-indicator"></span>
+                        <span id="connection-status">Disconnected</span>
+                    </div>
+                    <div class="text-slate-400" id="last-update">Last update: --</div>
+                    <div class="text-slate-400" id="total-vehicles">0 Vehicles</div>
+                </div>
+            </div>
+        </header>
+
+        <main class="flex-1 grid grid-cols-1 lg:grid-cols-[360px_minmax(0,1fr)]">
+            <aside class="bg-slate-900/60 border-r border-slate-800 p-6 space-y-6 overflow-y-auto">
+                <section>
+                    <h2 class="text-lg font-semibold text-slate-100 mb-4">Pickup Location</h2>
+                    <form id="location-form" class="space-y-4">
+                        <div>
+                            <label class="block text-sm text-slate-300 mb-1" for="latitude">Latitude</label>
+                            <input type="number" step="any" id="latitude" name="lat" value="18.756651"
+                                   class="w-full rounded-lg border border-slate-700 bg-slate-800/80 px-3 py-2 text-slate-100 focus:border-emerald-400 focus:outline-none">
+                        </div>
+                        <div>
+                            <label class="block text-sm text-slate-300 mb-1" for="longitude">Longitude</label>
+                            <input type="number" step="any" id="longitude" name="lng" value="98.994667"
+                                   class="w-full rounded-lg border border-slate-700 bg-slate-800/80 px-3 py-2 text-slate-100 focus:border-emerald-400 focus:outline-none">
+                        </div>
+                        <div>
+                            <label class="block text-sm text-slate-300 mb-1" for="address">Address</label>
+                            <input type="text" id="address" name="address" value="135 ซอย หมู่บ้านในฝัน"
+                                   class="w-full rounded-lg border border-slate-700 bg-slate-800/80 px-3 py-2 text-slate-100 focus:border-emerald-400 focus:outline-none">
+                        </div>
+                        <button type="submit"
+                                class="w-full rounded-lg bg-emerald-400 px-3 py-2 text-slate-900 font-semibold hover:bg-emerald-300 transition">
+                            Update Location
+                        </button>
+                    </form>
+                </section>
+
+                <section>
+                    <div class="flex items-center justify-between mb-3">
+                        <h2 class="text-lg font-semibold text-slate-100">Vehicle Categories</h2>
+                        <button id="clear-filter" class="text-xs text-emerald-400 hover:text-emerald-300">Show All</button>
+                    </div>
+                    <div id="category-list" class="space-y-3"></div>
+                </section>
+
+                <section>
+                    <h2 class="text-lg font-semibold text-slate-100 mb-4">Statistics</h2>
+                    <div class="grid gap-3" id="stats-grid"></div>
+                </section>
+            </aside>
+
+            <section class="relative bg-slate-950">
+                <div id="map" class="absolute inset-0"></div>
+                <div class="absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full bg-slate-900/80 px-4 py-2 text-sm text-slate-100 shadow-lg border border-slate-700">
+                    Auto refresh every 2 seconds
+                </div>
+            </section>
+        </main>
+    </div>
+
+    <script type="module" src="script.js"></script>
+</body>
+</html>

--- a/static/index.html
+++ b/static/index.html
@@ -77,7 +77,7 @@
             <section class="relative bg-slate-950 min-h-[520px] lg:min-h-full">
                 <div id="map" class="absolute inset-0"></div>
                 <div class="absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full bg-slate-900/80 px-4 py-2 text-sm text-slate-100 shadow-lg border border-slate-700">
-                    Auto refresh every 2 seconds
+                    Auto refresh every <span id="poll-interval">2</span> seconds
                 </div>
             </section>
         </main>

--- a/static/index.html
+++ b/static/index.html
@@ -74,7 +74,7 @@
                 </section>
             </aside>
 
-            <section class="relative bg-slate-950">
+            <section class="relative bg-slate-950 min-h-[520px] lg:min-h-full">
                 <div id="map" class="absolute inset-0"></div>
                 <div class="absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full bg-slate-900/80 px-4 py-2 text-sm text-slate-100 shadow-lg border border-slate-700">
                     Auto refresh every 2 seconds

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,325 @@
+const CATEGORY_CONFIG = {
+  "13591": { name: "Send Motorbike", color: "#34D399", emoji: "🟢" },
+  "13592": { name: "XL", color: "#60A5FA", emoji: "🔵" },
+  "13593": { name: "Bolt", color: "#A855F7", emoji: "🟣" },
+  "13595": { name: "Motorbike", color: "#FBBF24", emoji: "🟡" },
+  "13596": { name: "City Ride", color: "#F97316", emoji: "🟠" },
+};
+
+const OFFLINE_VEHICLES = [
+  { id: "1660285396", lat: 18.772542, lng: 98.979779, bearing: 278.77, category_id: "13591" },
+  { id: "1660285397", lat: 18.7684, lng: 98.98212, bearing: 102.1, category_id: "13593" },
+  { id: "1660285398", lat: 18.76123, lng: 98.99543, bearing: 45, category_id: "13596" },
+  { id: "1660285399", lat: 18.74931, lng: 98.98654, bearing: 310.2, category_id: "13592" },
+  { id: "1660285400", lat: 18.75512, lng: 98.9999, bearing: 210.4, category_id: "13595" },
+];
+
+const map = L.map("map", {
+  zoomControl: true,
+  scrollWheelZoom: true,
+}).setView([18.756651, 98.994667], 13);
+
+L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+  maxZoom: 19,
+  attribution: "© OpenStreetMap contributors",
+}).addTo(map);
+
+let pickupMarker = null;
+let markersLayer = L.layerGroup().addTo(map);
+let activeCategory = null;
+let pollingTimer = null;
+let latestData = null;
+let latestPickup = { lat: 18.756651, lng: 98.994667, address: "135 ซอย หมู่บ้านในฝัน" };
+
+const locationForm = document.getElementById("location-form");
+const categoryList = document.getElementById("category-list");
+const statsGrid = document.getElementById("stats-grid");
+const clearFilterBtn = document.getElementById("clear-filter");
+const connectionIndicator = document.getElementById("connection-indicator");
+const connectionStatus = document.getElementById("connection-status");
+const lastUpdate = document.getElementById("last-update");
+const totalVehicles = document.getElementById("total-vehicles");
+
+function rotateIcon(bearing) {
+  return `transform: rotate(${bearing}deg);`;
+}
+
+function calculateDistance(lat1, lon1, lat2, lon2) {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLon = ((lon2 - lon1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
+
+function buildOfflineData(pickup) {
+  const vehicles = OFFLINE_VEHICLES.map((vehicle) => {
+    const config = CATEGORY_CONFIG[vehicle.category_id] || {};
+    const distance_km = calculateDistance(pickup.lat, pickup.lng, vehicle.lat, vehicle.lng);
+    return {
+      ...vehicle,
+      category_name: config.name || "Unknown",
+      color: config.color || "#F1F5F9",
+      emoji: config.emoji || "🚗",
+      icon_url: null,
+      distance_km,
+    };
+  });
+
+  const categories = Object.entries(CATEGORY_CONFIG).map(([id, config]) => ({
+    id,
+    name: config.name,
+    color: config.color,
+    emoji: config.emoji,
+    count: vehicles.filter((vehicle) => vehicle.category_id === id).length,
+  }));
+
+  const nearest = vehicles.reduce((closest, vehicle) => {
+    if (!closest || vehicle.distance_km < closest.distance_km) {
+      return vehicle;
+    }
+    return closest;
+  }, null);
+
+  return {
+    vehicles,
+    categories,
+    stats: {
+      total: vehicles.length,
+      nearest,
+      last_update: new Date().toISOString().replace("T", " ").slice(0, 19),
+    },
+  };
+}
+
+function setPickupMarker(lat, lng) {
+  if (pickupMarker) {
+    pickupMarker.setLatLng([lat, lng]);
+  } else {
+    pickupMarker = L.marker([lat, lng], {
+      icon: L.divIcon({
+        className: "",
+        html: `<div class="marker-icon" style="--marker-color:#FACC15">📍</div>`,
+        iconSize: [36, 36],
+        iconAnchor: [18, 36],
+      }),
+    }).addTo(map);
+  }
+}
+
+function createVehicleIcon(vehicle) {
+  const { color, emoji } = vehicle;
+  const rotationStyle = rotateIcon(vehicle.bearing || 0);
+  const inverseRotation = -(vehicle.bearing || 0);
+  return L.divIcon({
+    className: "",
+    html: `
+      <div class="relative flex flex-col items-center">
+        <div class="marker-icon" style="--marker-color:${color}; ${rotationStyle}">
+          <span style="display:inline-block; transform: rotate(${inverseRotation}deg);">${emoji}</span>
+        </div>
+      </div>
+    `,
+    iconSize: [36, 36],
+    iconAnchor: [18, 36],
+  });
+}
+
+function renderMarkers(vehicles, pickup) {
+  markersLayer.clearLayers();
+  const bounds = [];
+
+  vehicles
+    .filter((vehicle) => !activeCategory || vehicle.category_id === activeCategory)
+    .forEach((vehicle) => {
+      const marker = L.marker([vehicle.lat, vehicle.lng], {
+        icon: createVehicleIcon(vehicle),
+      });
+
+      const distance = calculateDistance(pickup.lat, pickup.lng, vehicle.lat, vehicle.lng);
+      const popupHtml = `
+        <div class="space-y-2">
+          <div class="flex items-center gap-2 text-sm font-semibold">
+            <span style="color:${vehicle.color}">${vehicle.emoji}</span>
+            <span>${vehicle.category_name}</span>
+          </div>
+          <table class="popup-table">
+            <tr><td>ID</td><td>${vehicle.id}</td></tr>
+            <tr><td>Coords</td><td>${vehicle.lat.toFixed(5)}, ${vehicle.lng.toFixed(5)}</td></tr>
+            <tr><td>Bearing</td><td>${Math.round(vehicle.bearing)}°</td></tr>
+            <tr><td>Distance</td><td>${distance.toFixed(2)} km</td></tr>
+          </table>
+        </div>
+      `;
+      marker.bindPopup(popupHtml);
+      marker.addTo(markersLayer);
+      bounds.push([vehicle.lat, vehicle.lng]);
+    });
+
+  if (bounds.length > 0) {
+    const leafletBounds = L.latLngBounds(bounds);
+    map.fitBounds(leafletBounds.pad(0.25));
+  } else {
+    map.setView([pickup.lat, pickup.lng], map.getZoom());
+  }
+}
+
+function renderCategories(categories) {
+  categoryList.innerHTML = "";
+
+  categories.forEach((category) => {
+    const card = document.createElement("button");
+    card.className = `category-card w-full rounded-xl border border-slate-800 bg-slate-800/60 px-4 py-3 text-left transition focus:outline-none focus:ring-2 focus:ring-emerald-400 ${
+      activeCategory === category.id ? "ring-2 ring-emerald-400" : ""
+    }`;
+    card.dataset.categoryId = category.id;
+    card.innerHTML = `
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <span class="text-2xl" style="color:${category.color}">${category.emoji}</span>
+          <div>
+            <p class="font-semibold text-slate-100">${category.name}</p>
+            <p class="text-xs text-slate-400">Category ID: ${category.id}</p>
+          </div>
+        </div>
+        <span class="text-lg font-semibold text-emerald-300">${category.count}</span>
+      </div>
+    `;
+    card.addEventListener("click", () => {
+      activeCategory = activeCategory === category.id ? null : category.id;
+      renderCategories(categories);
+      if (latestData) {
+        renderMarkers(latestData.vehicles, latestPickup);
+      }
+    });
+    categoryList.appendChild(card);
+  });
+}
+
+function renderStats(data) {
+  const { total, nearest } = data.stats;
+  totalVehicles.textContent = `${total} Vehicles`;
+  const statsItems = [
+    {
+      label: "Total Vehicles",
+      value: total,
+    },
+    ...data.categories.map((category) => ({
+      label: category.name,
+      value: category.count,
+      color: category.color,
+    })),
+  ];
+
+  if (nearest) {
+    statsItems.push({
+      label: "Nearest Vehicle",
+      value: `${nearest.id} (${nearest.category_name})<br>${nearest.distance_km.toFixed(2)} km`,
+      color: nearest.color,
+    });
+  }
+
+  statsGrid.innerHTML = statsItems
+    .map((item) => {
+      const displayValue =
+        typeof item.value === "number" ? item.value.toLocaleString() : item.value;
+      return `
+        <div class="rounded-xl border border-slate-800 bg-slate-800/60 p-4">
+          <p class="text-xs uppercase tracking-wide text-slate-400">${item.label}</p>
+          <p class="mt-2 text-2xl font-semibold" style="color:${item.color || "#F8FAFC"}">${displayValue}</p>
+        </div>
+      `;
+    })
+    .join("");
+}
+
+async function fetchVehicles(payload) {
+  connectionIndicator.classList.replace("bg-red-400", "bg-amber-400");
+  connectionStatus.textContent = "Refreshing...";
+
+  try {
+    const response = await fetch("/api/vehicles", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw new Error("Failed to fetch vehicles");
+    }
+
+    const data = await response.json();
+    connectionIndicator.classList.replace("bg-amber-400", "bg-emerald-400");
+    connectionStatus.textContent = "Connected";
+    lastUpdate.textContent = `Last update: ${data.stats.last_update}`;
+    return data;
+  } catch (error) {
+    console.error(error);
+    connectionIndicator.classList.remove("bg-emerald-400", "bg-amber-400");
+    connectionIndicator.classList.add("bg-red-400");
+    connectionStatus.textContent = "Disconnected";
+    throw error;
+  }
+}
+
+async function refreshVehicles() {
+  const pickup = {
+    lat: parseFloat(locationForm.lat.value),
+    lng: parseFloat(locationForm.lng.value),
+    address: locationForm.address.value,
+  };
+
+  setPickupMarker(pickup.lat, pickup.lng);
+
+  try {
+    const data = await fetchVehicles(pickup);
+    latestData = data;
+    latestPickup = pickup;
+    renderCategories(data.categories);
+    renderStats(data);
+    renderMarkers(data.vehicles, pickup);
+  } catch (error) {
+    if (!latestData) {
+      latestData = buildOfflineData(pickup);
+      latestPickup = pickup;
+    }
+    renderCategories(latestData.categories);
+    renderStats(latestData);
+    renderMarkers(latestData.vehicles, latestPickup);
+  }
+}
+
+function startPolling() {
+  if (pollingTimer) {
+    clearInterval(pollingTimer);
+  }
+  pollingTimer = setInterval(() => {
+    refreshVehicles();
+  }, 2000);
+}
+
+locationForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+  activeCategory = null;
+  refreshVehicles();
+});
+
+clearFilterBtn.addEventListener("click", () => {
+  activeCategory = null;
+  if (latestData) {
+    renderCategories(latestData.categories);
+    renderMarkers(latestData.vehicles, latestPickup);
+  } else {
+    refreshVehicles();
+  }
+});
+
+refreshVehicles();
+startPolling();

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,65 @@
+:root {
+    color-scheme: dark;
+}
+
+html, body {
+    height: 100%;
+}
+
+#map {
+    min-height: 500px;
+}
+
+.leaflet-control-attribution,
+.leaflet-control-zoom {
+    filter: invert(1) hue-rotate(180deg);
+}
+
+.category-card {
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.category-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 30px -12px rgba(52, 211, 153, 0.6);
+}
+
+.marker-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1rem;
+    font-weight: 700;
+    color: #0f172a;
+    background: radial-gradient(circle at top, #f8fafc, var(--marker-color));
+    border-radius: 999px;
+    border: 2px solid rgba(15, 23, 42, 0.45);
+    width: 36px;
+    height: 36px;
+}
+
+.marker-icon::after {
+    content: "";
+    position: absolute;
+    bottom: -6px;
+    width: 0;
+    height: 0;
+    border-left: 6px solid transparent;
+    border-right: 6px solid transparent;
+    border-top: 8px solid var(--marker-color);
+}
+
+.popup-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.85rem;
+}
+
+.popup-table td {
+    padding: 2px 0;
+}
+
+.popup-table td:first-child {
+    color: #94a3b8;
+    padding-right: 0.5rem;
+}

--- a/static/styles.css
+++ b/static/styles.css
@@ -36,6 +36,8 @@ html, body {
     border: 2px solid rgba(15, 23, 42, 0.45);
     width: 36px;
     height: 36px;
+    position: relative;
+    overflow: hidden;
 }
 
 .marker-icon::after {
@@ -47,6 +49,12 @@ html, body {
     border-left: 6px solid transparent;
     border-right: 6px solid transparent;
     border-top: 8px solid var(--marker-color);
+}
+
+.marker-icon img {
+    width: 20px;
+    height: 20px;
+    object-fit: contain;
 }
 
 .popup-table {


### PR DESCRIPTION
## Summary
- add a Flask backend that proxies Bolt vehicle searches and falls back to sample data when the live API is unavailable
- build a Tailwind + Leaflet front-end with real-time polling, category filters, statistics, and vehicle popups
- include offline-friendly behaviour and requirements file for the runtime dependencies

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68e000823e848325bc83b5b48b0bbfc1