### PR TITLE
Refactor JWT module with enhanced management

### DIFF
--- a/jwt_analyzer.go
+++ b/jwt_analyzer.go
@@ -1,47 +1,276 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"log"
+	"strconv"
 	"time"
+
+	"go.uber.org/zap"
 )
 
-// JWTTokenData represents the JWT token data structure
+// JWTTokenData represents the legacy JWT token payload structure.
 type JWTTokenData struct {
 	Data struct {
 		UserID      int64 `json:"user_id"`
 		UserLoginID int64 `json:"user_login_id"`
 	} `json:"data"`
-	IAT int64 `json:"iat"` // Issued at
-	EXP int64 `json:"exp"` // Expires at
+	IAT int64  `json:"iat"`
+	EXP int64  `json:"exp"`
+	JTI string `json:"jti,omitempty"`
+
+	RawClaims map[string]interface{} `json:"-"`
 }
 
-// AnalyzeJWTToken analyzes a JWT token and extracts information
+// TokenMetadata captures normalized claim data for analysis and logging.
+type TokenMetadata struct {
+	RawClaims map[string]interface{}
+	UserID    string
+	LoginID   string
+	JTI       string
+	IssuedAt  time.Time
+	ExpiresAt time.Time
+	Expired   bool
+	Revoked   bool
+}
+
+// AnalyzeJWTToken decodes the payload into JWTTokenData while retaining raw claims.
 func AnalyzeJWTToken(token string) (*JWTTokenData, error) {
-	// Split JWT token into parts
 	parts := splitJWTToken(token)
 	if len(parts) != 3 {
 		return nil, fmt.Errorf("invalid JWT token format")
 	}
 
-	// Decode payload (second part)
 	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode JWT payload: %v", err)
+		return nil, fmt.Errorf("failed to decode JWT payload: %w", err)
 	}
 
-	// Parse JSON payload
-	var tokenData JWTTokenData
-	if err := json.Unmarshal(payload, &tokenData); err != nil {
-		return nil, fmt.Errorf("failed to parse JWT payload: %v", err)
+	var raw map[string]interface{}
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse JWT payload: %w", err)
 	}
 
-	return &tokenData, nil
+	tokenData := &JWTTokenData{RawClaims: raw}
+
+	if data, ok := raw["data"].(map[string]interface{}); ok {
+		if v, exists := data["user_id"]; exists {
+			tokenData.Data.UserID = parseToInt64(v)
+		}
+		if v, exists := data["user_login_id"]; exists {
+			tokenData.Data.UserLoginID = parseToInt64(v)
+		}
+	}
+
+	if v, ok := raw["iat"]; ok {
+		tokenData.IAT = parseToInt64(v)
+	}
+	if v, ok := raw["exp"]; ok {
+		tokenData.EXP = parseToInt64(v)
+	}
+	if v, ok := raw["jti"].(string); ok {
+		tokenData.JTI = v
+	}
+
+	return tokenData, nil
 }
 
-// splitJWTToken splits JWT token into header, payload, and signature
+// ExtractTokenMetadata normalizes claims and derives expiration status.
+func ExtractTokenMetadata(token string) (*TokenMetadata, error) {
+	tokenData, err := AnalyzeJWTToken(token)
+	if err != nil {
+		return nil, err
+	}
+
+	metadata := &TokenMetadata{
+		RawClaims: tokenData.RawClaims,
+		UserID:    normalizeUserID(tokenData),
+		LoginID:   normalizeLoginID(tokenData),
+		JTI:       tokenData.JTI,
+	}
+
+	if metadata.JTI == "" {
+		if jti, ok := tokenData.RawClaims["jti"].(string); ok {
+			metadata.JTI = jti
+		}
+	}
+
+	if tokenData.IAT != 0 {
+		metadata.IssuedAt = time.Unix(tokenData.IAT, 0)
+	} else if v, ok := tokenData.RawClaims["iat"]; ok {
+		metadata.IssuedAt = time.Unix(parseToInt64(v), 0)
+	}
+
+	if tokenData.EXP != 0 {
+		metadata.ExpiresAt = time.Unix(tokenData.EXP, 0)
+	} else if v, ok := tokenData.RawClaims["exp"]; ok {
+		metadata.ExpiresAt = time.Unix(parseToInt64(v), 0)
+	}
+
+	if !metadata.ExpiresAt.IsZero() && time.Now().After(metadata.ExpiresAt) {
+		metadata.Expired = true
+	}
+
+	return metadata, nil
+}
+
+// PrettyPrintClaims returns indented JSON claims for diagnostics.
+func PrettyPrintClaims(token string) (string, error) {
+	metadata, err := ExtractTokenMetadata(token)
+	if err != nil {
+		return "", err
+	}
+
+	claims, err := json.MarshalIndent(metadata.RawClaims, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	return string(claims), nil
+}
+
+// AnalyzeAndLogToken extracts metadata, optionally validates signature, and logs results.
+func AnalyzeAndLogToken(token string, validateSignature bool) (*TokenMetadata, error) {
+	metadata, err := ExtractTokenMetadata(token)
+	if err != nil {
+		return nil, err
+	}
+
+	manager := GetEnhancedJWTManager()
+	if manager != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if validateSignature {
+			claims, err := manager.ValidateToken(ctx, token)
+			if err != nil {
+				if errors.Is(err, errTokenRevoked) {
+					metadata.Revoked = true
+				} else if errors.Is(err, errTokenExpired) {
+					metadata.Expired = true
+				} else if logger := GetLogger(); logger != nil {
+					logger.Warn("Token validation failed",
+						zap.Error(err),
+						zap.String("jti", metadata.JTI),
+					)
+				}
+			} else if claims != nil {
+				metadata.UserID = claims.UserID
+				metadata.LoginID = claims.LoginID
+				metadata.JTI = claims.ID
+				metadata.IssuedAt = claims.IssuedAt.Time
+				metadata.ExpiresAt = claims.ExpiresAt.Time
+				metadata.Expired = time.Now().After(metadata.ExpiresAt)
+			}
+		} else if metadata.JTI != "" {
+			revoked, err := manager.IsTokenRevoked(ctx, metadata.JTI)
+			if err != nil {
+				if logger := GetLogger(); logger != nil {
+					logger.Warn("Failed to check token revocation",
+						zap.Error(err),
+						zap.String("jti", metadata.JTI),
+					)
+				}
+			} else {
+				metadata.Revoked = revoked
+			}
+		}
+	}
+
+	if logger := GetLogger(); logger != nil {
+		fields := []zap.Field{
+			zap.String("user_id", metadata.UserID),
+			zap.String("login_id", metadata.LoginID),
+			zap.String("jti", metadata.JTI),
+			zap.Time("issued_at", metadata.IssuedAt),
+			zap.Time("expires_at", metadata.ExpiresAt),
+			zap.Bool("expired", metadata.Expired),
+			zap.Bool("revoked", metadata.Revoked),
+		}
+		logger.Info("JWT token analysis", fields...)
+		if metadata.Expired {
+			logger.Warn("JWT token has expired", zap.Time("expires_at", metadata.ExpiresAt))
+		}
+		if metadata.Revoked {
+			logger.Warn("JWT token has been revoked", zap.String("jti", metadata.JTI))
+		}
+	}
+
+	return metadata, nil
+}
+
+// LogTokenInfo logs metadata without signature validation.
+func LogTokenInfo(token string) {
+	LogTokenInfoWithValidation(token, false)
+}
+
+// LogTokenInfoWithValidation allows toggling signature validation.
+func LogTokenInfoWithValidation(token string, validateSignature bool) {
+	if _, err := AnalyzeAndLogToken(token, validateSignature); err != nil {
+		if logger := GetLogger(); logger != nil {
+			logger.Error("Failed to analyze JWT token", zap.Error(err))
+		}
+	}
+}
+
+// IsTokenValid checks whether the token has expired.
+func IsTokenValid(token string) bool {
+	metadata, err := ExtractTokenMetadata(token)
+	if err != nil {
+		if logger := GetLogger(); logger != nil {
+			logger.Warn("Failed to analyze JWT token", zap.Error(err))
+		}
+		return false
+	}
+
+	if metadata.ExpiresAt.IsZero() {
+		return true
+	}
+
+	return time.Now().Before(metadata.ExpiresAt)
+}
+
+// GetTokenExpiry returns the expiry time of a JWT token.
+func GetTokenExpiry(token string) (time.Time, error) {
+	metadata, err := ExtractTokenMetadata(token)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return metadata.ExpiresAt, nil
+}
+
+// GetTokenIssuedAt returns the issued time of a JWT token.
+func GetTokenIssuedAt(token string) (time.Time, error) {
+	metadata, err := ExtractTokenMetadata(token)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return metadata.IssuedAt, nil
+}
+
+// GetTokenTimeRemaining returns the time remaining until token expires.
+func GetTokenTimeRemaining(token string) (time.Duration, error) {
+	metadata, err := ExtractTokenMetadata(token)
+	if err != nil {
+		return 0, err
+	}
+
+	if metadata.ExpiresAt.IsZero() {
+		return 0, nil
+	}
+
+	now := time.Now()
+	if now.After(metadata.ExpiresAt) {
+		return 0, nil
+	}
+
+	return metadata.ExpiresAt.Sub(now), nil
+}
+
+// splitJWTToken splits JWT token into header, payload, and signature.
 func splitJWTToken(token string) []string {
 	parts := make([]string, 0, 3)
 	start := 0
@@ -60,77 +289,46 @@ func splitJWTToken(token string) []string {
 	return parts
 }
 
-// IsTokenValid checks if a JWT token is still valid
-func IsTokenValid(token string) bool {
-	tokenData, err := AnalyzeJWTToken(token)
-	if err != nil {
-		log.Printf("⚠️ Failed to analyze JWT token: %v", err)
-		return false
+func parseToInt64(value interface{}) int64 {
+	switch v := value.(type) {
+	case int64:
+		return v
+	case int32:
+		return int64(v)
+	case float64:
+		return int64(v)
+	case float32:
+		return int64(v)
+	case json.Number:
+		parsed, _ := v.Int64()
+		return parsed
+	case string:
+		parsed, _ := strconv.ParseInt(v, 10, 64)
+		return parsed
+	default:
+		return 0
 	}
-
-	now := time.Now().Unix()
-	return now < tokenData.EXP
 }
 
-// GetTokenExpiry returns the expiry time of a JWT token
-func GetTokenExpiry(token string) (time.Time, error) {
-	tokenData, err := AnalyzeJWTToken(token)
-	if err != nil {
-		return time.Time{}, err
+func normalizeUserID(data *JWTTokenData) string {
+	if data.Data.UserID != 0 {
+		return strconv.FormatInt(data.Data.UserID, 10)
 	}
-
-	return time.Unix(tokenData.EXP, 0), nil
+	if raw, ok := data.RawClaims["user_id"].(string); ok {
+		return raw
+	}
+	if raw, ok := data.RawClaims["sub"].(string); ok {
+		return raw
+	}
+	return ""
 }
 
-// GetTokenIssuedAt returns the issued time of a JWT token
-func GetTokenIssuedAt(token string) (time.Time, error) {
-	tokenData, err := AnalyzeJWTToken(token)
-	if err != nil {
-		return time.Time{}, err
+func normalizeLoginID(data *JWTTokenData) string {
+	if data.Data.UserLoginID != 0 {
+		return strconv.FormatInt(data.Data.UserLoginID, 10)
 	}
-
-	return time.Unix(tokenData.IAT, 0), nil
-}
-
-// GetTokenTimeRemaining returns the time remaining until token expires
-func GetTokenTimeRemaining(token string) (time.Duration, error) {
-	expiry, err := GetTokenExpiry(token)
-	if err != nil {
-		return 0, err
+	if raw, ok := data.RawClaims["login_id"].(string); ok {
+		return raw
 	}
-
-	now := time.Now()
-	if now.After(expiry) {
-		return 0, nil // Token is expired
-	}
-
-	return expiry.Sub(now), nil
-}
-
-// LogTokenInfo logs detailed information about a JWT token
-func LogTokenInfo(token string) {
-	tokenData, err := AnalyzeJWTToken(token)
-	if err != nil {
-		log.Printf("⚠️ Failed to analyze JWT token: %v", err)
-		return
-	}
-
-	issuedAt := time.Unix(tokenData.IAT, 0)
-	expiresAt := time.Unix(tokenData.EXP, 0)
-	now := time.Now()
-
-	log.Printf("🔍 JWT Token Analysis:")
-	log.Printf("   User ID: %d", tokenData.Data.UserID)
-	log.Printf("   Login ID: %d", tokenData.Data.UserLoginID)
-	log.Printf("   Issued At: %s", issuedAt.Format(time.RFC3339))
-	log.Printf("   Expires At: %s", expiresAt.Format(time.RFC3339))
-	log.Printf("   Current Time: %s", now.Format(time.RFC3339))
-
-	if now.Before(expiresAt) {
-		remaining := expiresAt.Sub(now)
-		log.Printf("   Time Remaining: %s", remaining.String())
-		log.Printf("   Status: ✅ Valid")
-	} else {
-		log.Printf("   Status: ❌ Expired")
-	}
+	return ""
 }

--- a/jwt_generator.go
+++ b/jwt_generator.go
@@ -1,97 +1,184 @@
 package main
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
-	"log"
+	"errors"
+	"os"
+	"strconv"
+	"strings"
 	"time"
+
+	"go.uber.org/zap"
 )
 
-// JWTGenerator generates valid JWT tokens
+// JWTGenerator delegates token issuance to the EnhancedJWTManager.
 type JWTGenerator struct {
-	secretKey string
-	userID    int64
-	loginID   int64
+	manager *EnhancedJWTManager
+	userID  string
+	loginID string
 }
 
-// NewJWTGenerator creates a new JWT generator
-func NewJWTGenerator(secretKey string, userID, loginID int64) *JWTGenerator {
+// NewJWTGenerator constructs a generator that issues RS256 tokens through the enhanced manager.
+func NewJWTGenerator(manager *EnhancedJWTManager, userID, loginID string) *JWTGenerator {
 	return &JWTGenerator{
-		secretKey: secretKey,
-		userID:    userID,
-		loginID:   loginID,
+		manager: manager,
+		userID:  userID,
+		loginID: loginID,
 	}
 }
 
-// GenerateToken generates a new JWT token
-func (jg *JWTGenerator) GenerateToken() (string, error) {
-	// Create header
+// GenerateToken issues a new access token using the enhanced JWT manager.
+func (jg *JWTGenerator) GenerateToken(ctx context.Context) (string, error) {
+	if jg == nil || jg.manager == nil {
+		return "", errors.New("enhanced jwt manager is not initialized")
+	}
+
+	token, err := jg.manager.GenerateAccessToken(ctx, jg.userID, jg.loginID)
+	if err != nil {
+		if logger := GetLogger(); logger != nil {
+			logger.Error("Failed to generate access token",
+				zap.Error(err),
+				zap.String("user_id", jg.userID),
+				zap.String("login_id", jg.loginID),
+			)
+		}
+		return "", err
+	}
+
+	return token, nil
+}
+
+// LegacyJWTGenerator retains the old HS256 implementation for testing purposes only.
+type LegacyJWTGenerator struct {
+	secret  []byte
+	userID  int64
+	loginID int64
+	ttl     time.Duration
+}
+
+// NewLegacyJWTGenerator constructs a legacy generator with HS256 signing.
+func NewLegacyJWTGenerator(secret string, userID, loginID int64) *LegacyJWTGenerator {
+	return &LegacyJWTGenerator{
+		secret:  []byte(secret),
+		userID:  userID,
+		loginID: loginID,
+		ttl:     time.Hour,
+	}
+}
+
+// GenerateToken creates an HS256 token. Use only in tests.
+func (lg *LegacyJWTGenerator) GenerateToken() (string, error) {
+	if lg == nil || len(lg.secret) == 0 {
+		return "", errors.New("legacy jwt generator secret not configured")
+	}
+
 	header := map[string]interface{}{
 		"alg": "HS256",
 		"typ": "JWT",
 	}
-
-	// Create payload
 	now := time.Now()
 	payload := map[string]interface{}{
 		"data": map[string]interface{}{
-			"user_id":       jg.userID,
-			"user_login_id": jg.loginID,
+			"user_id":       lg.userID,
+			"user_login_id": lg.loginID,
 		},
 		"iat": now.Unix(),
-		"exp": now.Add(1 * time.Hour).Unix(), // 1 hour expiry
+		"exp": now.Add(lg.ttl).Unix(),
 	}
 
-	// Encode header
 	headerJSON, err := json.Marshal(header)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal header: %v", err)
+		return "", err
 	}
-	headerEncoded := base64.RawURLEncoding.EncodeToString(headerJSON)
-
-	// Encode payload
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal payload: %v", err)
+		return "", err
 	}
-	payloadEncoded := base64.RawURLEncoding.EncodeToString(payloadJSON)
 
-	// Create signature
-	message := headerEncoded + "." + payloadEncoded
-	signature := jg.createSignature(message)
-
-	// Combine all parts
+	message := base64.RawURLEncoding.EncodeToString(headerJSON) + "." + base64.RawURLEncoding.EncodeToString(payloadJSON)
+	signature := lg.sign(message)
 	token := message + "." + signature
 
-	log.Printf("🔑 Generated new JWT token with expiry: %s", now.Add(1*time.Hour).Format(time.RFC3339))
+	if logger := GetLogger(); logger != nil {
+		logger.Info("Legacy JWT token generated",
+			zap.Int64("user_id", lg.userID),
+			zap.Int64("login_id", lg.loginID),
+			zap.Time("expires_at", now.Add(lg.ttl)),
+			zap.Bool("legacy", true),
+		)
+	}
+
 	return token, nil
 }
 
-// createSignature creates HMAC-SHA256 signature
-func (jg *JWTGenerator) createSignature(message string) string {
-	h := hmac.New(sha256.New, []byte(jg.secretKey))
+func (lg *LegacyJWTGenerator) sign(message string) string {
+	h := hmac.New(sha256.New, lg.secret)
 	h.Write([]byte(message))
 	return base64.RawURLEncoding.EncodeToString(h.Sum(nil))
 }
 
-// Global JWT generator
-var jwtGenerator *JWTGenerator
+var (
+	jwtGenerator       *JWTGenerator
+	legacyJWTGenerator *LegacyJWTGenerator
+)
 
-// InitializeJWTGenerator initializes the global JWT generator
+// InitializeJWTGenerator wires the generator to the enhanced manager.
 func InitializeJWTGenerator() {
-	// Use a secret key (in production, this should be from environment variables)
-	secretKey := "your-secret-key-here"
-	jwtGenerator = NewJWTGenerator(secretKey, 283617495, 605354782)
-	log.Println("✅ JWT Generator initialized")
+	if jwtGenerator != nil {
+		return
+	}
+
+	manager := GetEnhancedJWTManager()
+	if manager == nil {
+		if logger := GetLogger(); logger != nil {
+			logger.Warn("Enhanced JWT manager not available for generator")
+		}
+		return
+	}
+
+	userID := strings.TrimSpace(os.Getenv("BOLT_JWT_USER_ID"))
+	if userID == "" {
+		userID = "283617495"
+	}
+
+	loginID := strings.TrimSpace(os.Getenv("BOLT_JWT_LOGIN_ID"))
+	if loginID == "" {
+		loginID = "605354782"
+	}
+
+	jwtGenerator = NewJWTGenerator(manager, userID, loginID)
+
+	if secret := strings.TrimSpace(os.Getenv("LEGACY_JWT_SECRET")); secret != "" {
+		uid, _ := strconv.ParseInt(userID, 10, 64)
+		lid, _ := strconv.ParseInt(loginID, 10, 64)
+		legacyJWTGenerator = NewLegacyJWTGenerator(secret, uid, lid)
+	}
+
+	if logger := GetLogger(); logger != nil {
+		logger.Info("JWT generator initialized",
+			zap.String("user_id", userID),
+			zap.String("login_id", loginID),
+			zap.Bool("legacy_enabled", legacyJWTGenerator != nil),
+		)
+	}
 }
 
-// GenerateNewJWTToken generates a new JWT token
+// GenerateNewJWTToken returns a new RS256 access token.
 func GenerateNewJWTToken() (string, error) {
 	if jwtGenerator == nil {
 		InitializeJWTGenerator()
 	}
-	return jwtGenerator.GenerateToken()
+	if jwtGenerator == nil {
+		return "", errors.New("jwt generator not initialized")
+	}
+	return jwtGenerator.GenerateToken(context.Background())
+}
+
+// GetLegacyJWTGenerator exposes the HS256 generator for test environments only.
+func GetLegacyJWTGenerator() *LegacyJWTGenerator {
+	return legacyJWTGenerator
 }

--- a/jwt_manager.go
+++ b/jwt_manager.go
@@ -7,20 +7,25 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
-	"log"
+	"math/rand"
 	"net/http"
 	"net/url"
+	"os"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 // Constants for Bolt API token refresh
 const (
 	BASE_URL = "https://node.bolt.eu"
 	ENDPOINT = "/user-auth/profile/auth/getAccessToken"
-	OLD_JWT  = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkYXRhIjp7InVzZXJfaWQiOjI4MzYxNzQ5NSwidXNlcl9sb2dpbl9pZCI6NjA1MzU0NzgyLCJqdGkiOiIyYmM5ZTg5NS03MTAzLTRjZDUtOGI5Zi01MTExMzFlMjdhODIifSwiaWF0IjoxNzU5NjQyNzAxLCJleHAiOjE3OTEwOTIzMDF9.ZHbJ_VMbXHjlhGjMWbF-I_jYvWOwgNYClxVgmrV4v44"
 
 	// Error codes
 	ERROR_TOO_MANY_REQUESTS     = 1005
@@ -29,7 +34,13 @@ const (
 	// Rate limiting
 	MAX_CONCURRENT_REQUESTS = 5
 	REQUESTS_PER_SECOND     = 5
+
+	defaultMaxRefreshAttempts = 5
+	defaultBreakerFailures    = 4
+	defaultBreakerOpen        = 2 * time.Minute
 )
+
+const metricsServiceExternalJWT = "external_jwt"
 
 // Query parameters for token refresh
 var queryParams = map[string]string{
@@ -74,65 +85,124 @@ type JWTToken struct {
 	IssuedAt  time.Time `json:"issued_at"`
 	UserID    int64     `json:"user_id"`
 	LoginID   int64     `json:"login_id"`
+	JTI       string    `json:"jti"`
+}
+
+// TokenError represents a structured error during token operations.
+type TokenError struct {
+	Operation  string
+	Cause      error
+	StatusCode int
+	Attempt    int
+}
+
+func (e *TokenError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.StatusCode > 0 {
+		return fmt.Sprintf("%s failed (status=%d, attempt=%d): %v", e.Operation, e.StatusCode, e.Attempt, e.Cause)
+	}
+	return fmt.Sprintf("%s failed (attempt=%d): %v", e.Operation, e.Attempt, e.Cause)
+}
+
+func (e *TokenError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
 }
 
 // RateLimiter manages API rate limiting with token bucket algorithm
 type RateLimiter struct {
 	limiter           chan struct{}
-	rate              <-chan time.Time
+	ticker            *time.Ticker
 	maxConcurrent     int
 	requestsPerSecond int
 }
 
 // NewRateLimiter creates a new rate limiter
 func NewRateLimiter(maxConcurrent int, requestsPerSecond int) *RateLimiter {
+	if requestsPerSecond <= 0 {
+		requestsPerSecond = 1
+	}
+
+	interval := time.Second / time.Duration(requestsPerSecond)
+	if interval <= 0 {
+		interval = time.Second
+	}
+
 	return &RateLimiter{
 		limiter:           make(chan struct{}, maxConcurrent),
-		rate:              time.Tick(time.Second / time.Duration(requestsPerSecond)),
+		ticker:            time.NewTicker(interval),
 		maxConcurrent:     maxConcurrent,
 		requestsPerSecond: requestsPerSecond,
 	}
 }
 
 // Acquire acquires a rate limit slot with proper error handling
-func (rl *RateLimiter) Acquire() {
-	// Wait for rate tick (throttle requests per second)
-	<-rl.rate
+func (rl *RateLimiter) Acquire(ctx context.Context) error {
+	if rl == nil {
+		return nil
+	}
 
-	// Acquire concurrent request slot
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-rl.ticker.C:
+	}
+
 	select {
 	case rl.limiter <- struct{}{}:
-		// Successfully acquired slot
-		log.Printf("🔒 Rate limiter acquired (current: %d/%d concurrent requests)",
-			len(rl.limiter), rl.maxConcurrent)
-	default:
-		// No available slots, wait for one to be released
-		log.Printf("⏳ Rate limiter queue full, waiting for slot...")
-		rl.limiter <- struct{}{}
+		if logger := GetLogger(); logger != nil {
+			logger.Debug("Rate limiter acquired",
+				zap.Int("current", len(rl.limiter)),
+				zap.Int("max", rl.maxConcurrent),
+			)
+		}
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 
 // Release releases a rate limit slot
 func (rl *RateLimiter) Release() {
+	if rl == nil {
+		return
+	}
+
 	select {
 	case <-rl.limiter:
-		// Successfully released slot
-		log.Printf("🔓 Rate limiter released (current: %d/%d concurrent requests)",
-			len(rl.limiter), rl.maxConcurrent)
+		if logger := GetLogger(); logger != nil {
+			logger.Debug("Rate limiter released",
+				zap.Int("current", len(rl.limiter)),
+				zap.Int("max", rl.maxConcurrent),
+			)
+		}
 	default:
-		// No slots to release (shouldn't happen in normal operation)
-		log.Printf("⚠️ Attempted to release rate limiter slot but none were held")
 	}
 }
 
 // GetStatus returns current rate limiter status
 func (rl *RateLimiter) GetStatus() map[string]interface{} {
+	if rl == nil {
+		return map[string]interface{}{}
+	}
 	return map[string]interface{}{
 		"max_concurrent":      rl.maxConcurrent,
 		"requests_per_second": rl.requestsPerSecond,
 		"current_requests":    len(rl.limiter),
 		"available_slots":     rl.maxConcurrent - len(rl.limiter),
 	}
+}
+
+// Stop releases ticker resources.
+func (rl *RateLimiter) Stop() {
+	if rl == nil {
+		return
+	}
+	rl.ticker.Stop()
 }
 
 // decodeBody handles gzip/deflate response decoding
@@ -161,71 +231,129 @@ func decodeBody(resp *http.Response) ([]byte, error) {
 	return body, nil
 }
 
-// JWTManager manages JWT tokens with automatic renewal
-type JWTManager struct {
+// ExternalJWTManager manages JWT tokens with automatic renewal
+type ExternalJWTManager struct {
 	currentToken *JWTToken
 	mutex        sync.RWMutex
-	renewalTime  time.Duration // Time before expiry to renew token
+	renewalTime  time.Duration
 	userID       int64
 	loginID      int64
 	baseURL      string
 	httpClient   *http.Client
 	rateLimiter  *RateLimiter
+
+	refreshInterval    time.Duration
+	maxRefreshAttempts int
+	backoffBase        time.Duration
+	seedToken          string
+	backgroundCtx      context.Context
+	backgroundCancel   context.CancelFunc
+	backgroundOnce     sync.Once
+
+	breakerMu           sync.Mutex
+	consecutiveFailures int
+	breakerOpenUntil    time.Time
+	breakerMaxFailures  int
+	breakerOpenDuration time.Duration
 }
 
-// NewJWTManager creates a new JWT manager
-func NewJWTManager(userID, loginID int64, baseURL string, httpClient *http.Client) *JWTManager {
-	return &JWTManager{
-		renewalTime: 10 * time.Minute, // Renew 10 minutes before expiry
-		userID:      userID,
-		loginID:     loginID,
-		baseURL:     baseURL,
-		httpClient:  httpClient,
-		rateLimiter: NewRateLimiter(MAX_CONCURRENT_REQUESTS, REQUESTS_PER_SECOND),
+type JWTManager = ExternalJWTManager
+
+func NewExternalJWTManager(userID, loginID int64, baseURL string, httpClient *http.Client) *ExternalJWTManager {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
 	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	manager := &ExternalJWTManager{
+		renewalTime:         10 * time.Minute,
+		userID:              userID,
+		loginID:             loginID,
+		baseURL:             baseURL,
+		httpClient:          httpClient,
+		rateLimiter:         NewRateLimiter(MAX_CONCURRENT_REQUESTS, REQUESTS_PER_SECOND),
+		refreshInterval:     time.Minute,
+		maxRefreshAttempts:  defaultMaxRefreshAttempts,
+		backoffBase:         500 * time.Millisecond,
+		seedToken:           strings.TrimSpace(os.Getenv("BOLT_API_SEED_TOKEN")),
+		backgroundCtx:       ctx,
+		backgroundCancel:    cancel,
+		breakerMaxFailures:  defaultBreakerFailures,
+		breakerOpenDuration: defaultBreakerOpen,
+	}
+
+	manager.startBackgroundRefresher()
+
+	return manager
 }
 
-// GetValidToken returns a valid JWT token, renewing if necessary
-func (jm *JWTManager) GetValidToken() (string, error) {
+func NewJWTManager(userID, loginID int64, baseURL string, httpClient *http.Client) *ExternalJWTManager {
+	return NewExternalJWTManager(userID, loginID, baseURL, httpClient)
+}
+
+func (jm *ExternalJWTManager) GetValidToken() (string, error) {
+	if jm == nil {
+		return "", errors.New("jwt manager is not initialized")
+	}
+
+	jm.startBackgroundRefresher()
+
 	jm.mutex.Lock()
 	defer jm.mutex.Unlock()
 
-	// Check if we have a token and if it's still valid
 	if jm.currentToken != nil && time.Now().Before(jm.currentToken.ExpiresAt) {
-		// Check if we need to renew soon
 		if time.Until(jm.currentToken.ExpiresAt) < jm.renewalTime {
-			// Renew token in background
-			go jm.renewToken()
+			go jm.triggerAsyncRefresh()
 		}
 		return jm.currentToken.Token, nil
 	}
 
-	// No valid token, generate a new one
-	return jm.generateNewToken()
+	return jm.generateNewTokenLocked(jm.backgroundCtx)
 }
 
-// refreshToken refreshes the JWT token by calling the Bolt API with retry logic
-func (jm *JWTManager) refreshToken() (string, error) {
-	// Build URL with query parameters
-	reqURL, err := url.Parse(BASE_URL + ENDPOINT)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse URL: %v", err)
+func (jm *ExternalJWTManager) generateNewTokenLocked(ctx context.Context) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
-	// Add query parameters
-	query := reqURL.Query()
-	for key, value := range queryParams {
-		query.Add(key, value)
-	}
-	reqURL.RawQuery = query.Encode()
-
-	// Determine which token to use for authorization
-	authToken := OLD_JWT
+	authToken := jm.seedToken
 	if jm.currentToken != nil && jm.currentToken.Token != "" {
 		authToken = jm.currentToken.Token
 	}
 
-	// Enhanced headers for better compatibility
+	tokenData, err := jm.refreshToken(ctx, authToken)
+	if err != nil {
+		return "", err
+	}
+
+	jm.currentToken = tokenData
+
+	return tokenData.Token, nil
+}
+
+func (jm *ExternalJWTManager) refreshToken(ctx context.Context, authToken string) (*JWTToken, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if open, remaining := jm.isCircuitOpen(); open {
+		err := &TokenError{Operation: "refreshToken", Cause: fmt.Errorf("circuit breaker open for %s", remaining), Attempt: 0}
+		jm.logRefreshError("circuit_open", err)
+		return nil, err
+	}
+
+	reqURL, err := url.Parse(BASE_URL + ENDPOINT)
+	if err != nil {
+		return nil, &TokenError{Operation: "refreshToken", Cause: err}
+	}
+
+	query := reqURL.Query()
+	for key, value := range queryParams {
+		query.Set(key, value)
+	}
+	reqURL.RawQuery = query.Encode()
+
 	headers := map[string]string{
 		"Host":               "node.bolt.eu",
 		"Cache-Control":      "max-age=0",
@@ -240,356 +368,350 @@ func (jm *JWTManager) refreshToken() (string, error) {
 		"Sec-Fetch-User":     "?1",
 		"Sec-Fetch-Dest":     "document",
 		"Accept-Encoding":    "gzip, deflate",
-		"Authorization":      "Bearer " + authToken,
+	}
+	if authToken != "" {
+		headers["Authorization"] = "Bearer " + authToken
 	}
 
-	// Exponential backoff for retries
-	backoff := []time.Duration{500 * time.Millisecond, 1 * time.Second, 2 * time.Second}
+	for attempt := 1; attempt <= jm.maxRefreshAttempts; attempt++ {
+		attemptCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 
-	for i := 0; i < len(backoff); i++ {
-		// Apply rate limiting
-		jm.rateLimiter.Acquire()
-		defer jm.rateLimiter.Release()
-
-		// Create request with context
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		req, err := http.NewRequestWithContext(ctx, "POST", reqURL.String(), nil)
-		if err != nil {
+		if err := jm.rateLimiter.Acquire(attemptCtx); err != nil {
 			cancel()
-			return "", fmt.Errorf("failed to create request: %v", err)
+			return nil, &TokenError{Operation: "refreshToken", Cause: err, Attempt: attempt}
 		}
 
-		// Set headers
+		req, err := http.NewRequestWithContext(attemptCtx, "POST", reqURL.String(), nil)
+		if err != nil {
+			jm.rateLimiter.Release()
+			cancel()
+			return nil, &TokenError{Operation: "refreshToken", Cause: err, Attempt: attempt}
+		}
+
 		for k, v := range headers {
 			req.Header.Set(k, v)
 		}
 
-		// Make request
 		resp, err := jm.httpClient.Do(req)
+		jm.rateLimiter.Release()
+		if err != nil {
+			cancel()
+			jm.recordRefreshFailure(err)
+			jm.logRefreshError("network_error", &TokenError{Operation: "refreshToken", Cause: err, Attempt: attempt})
+			if attempt == jm.maxRefreshAttempts {
+				return nil, &TokenError{Operation: "refreshToken", Cause: err, Attempt: attempt}
+			}
+			time.Sleep(jm.backoffWithJitter(attempt))
+			continue
+		}
+
+		body, err := decodeBody(resp)
+		resp.Body.Close()
 		cancel()
 		if err != nil {
-			log.Printf("⚠️ Request failed (attempt %d): %v", i+1, err)
-			if i < len(backoff)-1 {
-				time.Sleep(backoff[i])
-				continue
+			jm.recordRefreshFailure(err)
+			jm.logRefreshError("decode_error", &TokenError{Operation: "refreshToken", Cause: err, Attempt: attempt})
+			if attempt == jm.maxRefreshAttempts {
+				return nil, &TokenError{Operation: "refreshToken", Cause: err, Attempt: attempt}
 			}
-			return "", fmt.Errorf("failed to make request after retries: %v", err)
+			time.Sleep(jm.backoffWithJitter(attempt))
+			continue
 		}
 
-		// Read and decode response body (handles gzip/deflate)
-		body, err := decodeBody(resp)
-		if err != nil {
-			log.Printf("⚠️ Failed to decode response body (attempt %d): %v", i+1, err)
-			if i < len(backoff)-1 {
-				time.Sleep(backoff[i])
-				continue
+		if resp.StatusCode == http.StatusTooManyRequests {
+			errAttempt := &TokenError{Operation: "refreshToken", Cause: fmt.Errorf("too many requests"), StatusCode: resp.StatusCode, Attempt: attempt}
+			jm.recordRefreshFailure(errAttempt)
+			jm.logRefreshError("rate_limited", errAttempt)
+			if attempt == jm.maxRefreshAttempts {
+				return nil, errAttempt
 			}
-			return "", fmt.Errorf("failed to decode response body: %v", err)
+			time.Sleep(jm.backoffWithJitter(attempt))
+			continue
 		}
 
-		// Log response for debugging
-		log.Printf("🔍 API Response Status: %d (attempt %d)", resp.StatusCode, i+1)
-		log.Printf("🔍 API Response Body: %s", string(body))
-
-		// Handle HTTP 429 (Too Many Requests)
-		if resp.StatusCode == 429 {
-			log.Printf("⚠️ HTTP 429 TOO_MANY_REQUESTS → retry with backoff (attempt %d)", i+1)
-			if i < len(backoff)-1 {
-				time.Sleep(backoff[i])
-				continue
+		if resp.StatusCode != http.StatusOK {
+			errAttempt := &TokenError{Operation: "refreshToken", Cause: fmt.Errorf(string(body)), StatusCode: resp.StatusCode, Attempt: attempt}
+			jm.recordRefreshFailure(errAttempt)
+			jm.logRefreshError("status_error", errAttempt)
+			if attempt == jm.maxRefreshAttempts {
+				return nil, errAttempt
 			}
-			return "", fmt.Errorf("too many requests after retries")
+			time.Sleep(jm.backoffWithJitter(attempt))
+			continue
 		}
 
-		// Check status code
-		if resp.StatusCode != 200 {
-			log.Printf("⚠️ API returned status %d (attempt %d): %s", resp.StatusCode, i+1, string(body))
-			if i < len(backoff)-1 {
-				time.Sleep(backoff[i])
-				continue
-			}
-			return "", fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
-		}
-
-		// Parse JSON response
 		var tokenResp TokenRefreshResponse
 		if err := json.Unmarshal(body, &tokenResp); err != nil {
-			log.Printf("⚠️ Failed to parse response JSON (attempt %d): %v", i+1, err)
-			if i < len(backoff)-1 {
-				time.Sleep(backoff[i])
-				continue
+			jm.recordRefreshFailure(err)
+			jm.logRefreshError("unmarshal_error", &TokenError{Operation: "refreshToken", Cause: err, Attempt: attempt})
+			if attempt == jm.maxRefreshAttempts {
+				return nil, &TokenError{Operation: "refreshToken", Cause: err, Attempt: attempt}
 			}
-			return "", fmt.Errorf("failed to parse response JSON: %v", err)
+			time.Sleep(jm.backoffWithJitter(attempt))
+			continue
 		}
 
-		// Handle specific error codes with enhanced logging
 		if tokenResp.Code == ERROR_REFRESH_TOKEN_INVALID {
-			log.Printf("⚠️ REFRESH_TOKEN_INVALID (code 210) → regenerate token")
-			log.Printf("🔄 Content-Encoding: %s, Response size: %d bytes",
-				resp.Header.Get("Content-Encoding"), len(body))
-			return jm.regenerateRefreshToken()
+			errAttempt := &TokenError{Operation: "refreshToken", Cause: fmt.Errorf("refresh token invalid"), Attempt: attempt}
+			jm.recordRefreshFailure(errAttempt)
+			jm.logRefreshError("refresh_token_invalid", errAttempt)
+			return nil, errAttempt
 		}
 
 		if tokenResp.Code == ERROR_TOO_MANY_REQUESTS {
-			log.Printf("⚠️ TOO_MANY_REQUESTS (code 1005) → retry with backoff (attempt %d)", i+1)
-			log.Printf("🔄 Content-Encoding: %s, Response size: %d bytes",
-				resp.Header.Get("Content-Encoding"), len(body))
-			if i < len(backoff)-1 {
-				log.Printf("⏱️ Waiting %v before retry...", backoff[i])
-				time.Sleep(backoff[i])
-				continue
+			errAttempt := &TokenError{Operation: "refreshToken", Cause: fmt.Errorf("too many requests"), Attempt: attempt}
+			jm.recordRefreshFailure(errAttempt)
+			jm.logRefreshError("rate_limited_code", errAttempt)
+			if attempt == jm.maxRefreshAttempts {
+				return nil, errAttempt
 			}
-			return "", fmt.Errorf("too many requests after retries")
+			time.Sleep(jm.backoffWithJitter(attempt))
+			continue
 		}
 
-		// Check if API call was successful
 		if tokenResp.Code != 0 {
-			log.Printf("⚠️ API returned error code %d (attempt %d): %s", tokenResp.Code, i+1, tokenResp.Message)
-			if i < len(backoff)-1 {
-				time.Sleep(backoff[i])
-				continue
+			errAttempt := &TokenError{Operation: "refreshToken", Cause: fmt.Errorf(tokenResp.Message), Attempt: attempt}
+			jm.recordRefreshFailure(errAttempt)
+			jm.logRefreshError("api_error", errAttempt)
+			if attempt == jm.maxRefreshAttempts {
+				return nil, errAttempt
 			}
-			return "", fmt.Errorf("API returned error code %d: %s", tokenResp.Code, tokenResp.Message)
+			time.Sleep(jm.backoffWithJitter(attempt))
+			continue
 		}
 
 		if tokenResp.Data.AccessToken == "" {
-			log.Printf("⚠️ No access token in response (attempt %d)", i+1)
-			if i < len(backoff)-1 {
-				time.Sleep(backoff[i])
-				continue
+			errAttempt := &TokenError{Operation: "refreshToken", Cause: fmt.Errorf("no access token in response"), Attempt: attempt}
+			jm.recordRefreshFailure(errAttempt)
+			jm.logRefreshError("missing_token", errAttempt)
+			if attempt == jm.maxRefreshAttempts {
+				return nil, errAttempt
 			}
-			return "", fmt.Errorf("no access token in response")
+			time.Sleep(jm.backoffWithJitter(attempt))
+			continue
 		}
 
-		// Analyze the new token to get timing information
-		LogTokenInfo(tokenResp.Data.AccessToken)
+		tokenString := tokenResp.Data.AccessToken
 
-		// Get token expiry and issued time
-		expiresAt, err := GetTokenExpiry(tokenResp.Data.AccessToken)
-		if err != nil {
-			log.Printf("⚠️ Failed to get token expiry: %v", err)
-			// If we can't parse expiry, use expires_in_seconds from response or default
-			if tokenResp.Data.ExpiresInSeconds > 0 {
-				expiresAt = time.Now().Add(time.Duration(tokenResp.Data.ExpiresInSeconds) * time.Second)
-			} else {
-				expiresAt = time.Now().Add(1 * time.Hour)
-			}
+		metadata, metaErr := ExtractTokenMetadata(tokenString)
+		if metaErr != nil {
+			jm.logRefreshError("metadata_extract_failed", metaErr)
 		}
 
-		issuedAt, err := GetTokenIssuedAt(tokenResp.Data.AccessToken)
-		if err != nil {
-			log.Printf("⚠️ Failed to get token issued time: %v", err)
-			issuedAt = time.Now()
+		expiresAt := time.Now().Add(time.Hour)
+		if metadata != nil {
+			expiresAt = metadata.ExpiresAt
+		} else if tokenResp.Data.ExpiresInSeconds > 0 {
+			expiresAt = time.Now().Add(time.Duration(tokenResp.Data.ExpiresInSeconds) * time.Second)
+		} else if tokenResp.Data.ExpiresTimestamp > 0 {
+			expiresAt = time.Unix(tokenResp.Data.ExpiresTimestamp, 0)
 		}
 
-		// Update current token
-		jm.currentToken = &JWTToken{
-			Token:     tokenResp.Data.AccessToken,
+		issuedAt := time.Now()
+		if metadata != nil {
+			issuedAt = metadata.IssuedAt
+		}
+
+		tokenInfo := &JWTToken{
+			Token:     tokenString,
 			ExpiresAt: expiresAt,
 			IssuedAt:  issuedAt,
 			UserID:    jm.userID,
 			LoginID:   jm.loginID,
 		}
 
-		log.Printf("✅ Successfully refreshed JWT token (expires: %s)", expiresAt.Format(time.RFC3339))
-		log.Printf("📊 API Response: expires_in=%ds, next_update_in=%ds",
-			tokenResp.Data.ExpiresInSeconds, tokenResp.Data.NextUpdateInSeconds)
-		log.Printf("🔄 Content-Encoding: %s, Response size: %d bytes",
-			resp.Header.Get("Content-Encoding"), len(body))
-		return tokenResp.Data.AccessToken, nil
+		if metadata != nil {
+			if parsedID, parseErr := strconv.ParseInt(metadata.UserID, 10, 64); parseErr == nil {
+				tokenInfo.UserID = parsedID
+			}
+			if parsedLogin, parseErr := strconv.ParseInt(metadata.LoginID, 10, 64); parseErr == nil {
+				tokenInfo.LoginID = parsedLogin
+			}
+			tokenInfo.JTI = metadata.JTI
+		}
+
+		jm.recordRefreshSuccess()
+
+		if logger := GetLogger(); logger != nil {
+			fields := []zap.Field{
+				zap.Int64("user_id", tokenInfo.UserID),
+				zap.Int64("login_id", tokenInfo.LoginID),
+				zap.Time("expires_at", tokenInfo.ExpiresAt),
+			}
+			if tokenInfo.JTI != "" {
+				fields = append(fields, zap.String("jti", tokenInfo.JTI))
+			}
+			logger.Info("External JWT token refreshed", fields...)
+		}
+
+		LogTokenInfoWithValidation(tokenString, false)
+
+		return tokenInfo, nil
 	}
 
-	return "", fmt.Errorf("failed to refresh JWT after all retries")
+	err := &TokenError{Operation: "refreshToken", Cause: fmt.Errorf("exhausted retries"), Attempt: jm.maxRefreshAttempts}
+	jm.logRefreshError("exhausted_retries", err)
+	return nil, err
 }
 
-// regenerateRefreshToken handles error 210 by regenerating the refresh token
-func (jm *JWTManager) regenerateRefreshToken() (string, error) {
-	log.Printf("🔄 Regenerating refresh token due to error 210...")
-
-	// For now, we'll use a fallback approach since we don't have the full OAuth flow
-	// In a real implementation, this would trigger the full OAuth login process
-	fallbackToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkYXRhIjp7InVzZXJfaWQiOjI4NDU4OTAwNiwidXNlcl9sb2dpbl9pZCI6NjA2MzMxMDgxfSwiaWF0IjoxNzU5ODcwMTgxLCJleHAiOjE3NTk4NzM3ODF9.LZbRjUU4MUgAqITB7rQmn5j8BG9yLho12WBB7sReKxw"
-
-	// Analyze the fallback token
-	LogTokenInfo(fallbackToken)
-
-	// Check if fallback token is still valid
-	if IsTokenValid(fallbackToken) {
-		expiresAt, err := GetTokenExpiry(fallbackToken)
-		if err != nil {
-			log.Printf("⚠️ Failed to get token expiry: %v", err)
-			expiresAt = time.Now().Add(1 * time.Hour)
-		}
-
-		issuedAt, err := GetTokenIssuedAt(fallbackToken)
-		if err != nil {
-			log.Printf("⚠️ Failed to get token issued time: %v", err)
-			issuedAt = time.Now()
-		}
-
-		jm.currentToken = &JWTToken{
-			Token:     fallbackToken,
-			ExpiresAt: expiresAt,
-			IssuedAt:  issuedAt,
-			UserID:    jm.userID,
-			LoginID:   jm.loginID,
-		}
-
-		log.Printf("✅ Using regenerated fallback JWT token (expires: %s)", expiresAt.Format(time.RFC3339))
-		return fallbackToken, nil
+func (jm *ExternalJWTManager) backoffWithJitter(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
 	}
-
-	// Even if fallback token is expired, use it anyway and let API handle 401
-	now := time.Now()
-	expiresAt := now.Add(1 * time.Hour)
-	issuedAt := now
-
-	jm.currentToken = &JWTToken{
-		Token:     fallbackToken,
-		ExpiresAt: expiresAt,
-		IssuedAt:  issuedAt,
-		UserID:    jm.userID,
-		LoginID:   jm.loginID,
+	base := jm.backoffBase
+	if base <= 0 {
+		base = 500 * time.Millisecond
 	}
-
-	log.Printf("⚠️ Using expired regenerated token (will trigger 401)")
-	return fallbackToken, nil
+	max := base * time.Duration(1<<uint(attempt-1))
+	randSrc := rand.New(rand.NewSource(time.Now().UnixNano()))
+	jitter := time.Duration(randSrc.Int63n(int64(max/2) + 1))
+	return max + jitter
 }
 
-// generateNewToken generates a new JWT token by calling refreshToken
-func (jm *JWTManager) generateNewToken() (string, error) {
-	// Try to refresh token from API
-	newToken, err := jm.refreshToken()
-	if err != nil {
-		log.Printf("⚠️ Failed to refresh token from API: %v", err)
+func (jm *ExternalJWTManager) recordRefreshFailure(err error) {
+	jm.breakerMu.Lock()
+	defer jm.breakerMu.Unlock()
 
-		// Fallback to static token if refresh fails
-		fallbackToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkYXRhIjp7InVzZXJfaWQiOjI4NDU4OTAwNiwidXNlcl9sb2dpbl9pZCI6NjA2MzMxMDgxfSwiaWF0IjoxNzU5ODcwMTgxLCJleHAiOjE3NTk4NzM3ODF9.LZbRjUU4MUgAqITB7rQmn5j8BG9yLho12WBB7sReKxw"
-
-		// Analyze the fallback token
-		LogTokenInfo(fallbackToken)
-
-		// Check if fallback token is still valid
-		if IsTokenValid(fallbackToken) {
-			expiresAt, err := GetTokenExpiry(fallbackToken)
-			if err != nil {
-				log.Printf("⚠️ Failed to get token expiry: %v", err)
-				expiresAt = time.Now().Add(1 * time.Hour)
-			}
-
-			issuedAt, err := GetTokenIssuedAt(fallbackToken)
-			if err != nil {
-				log.Printf("⚠️ Failed to get token issued time: %v", err)
-				issuedAt = time.Now()
-			}
-
-			jm.currentToken = &JWTToken{
-				Token:     fallbackToken,
-				ExpiresAt: expiresAt,
-				IssuedAt:  issuedAt,
-				UserID:    jm.userID,
-				LoginID:   jm.loginID,
-			}
-
-			log.Printf("✅ Using fallback JWT token (expires: %s)", expiresAt.Format(time.RFC3339))
-			return fallbackToken, nil
-		}
-
-		// Even fallback token is expired, use it anyway and let API handle 401
-		now := time.Now()
-		expiresAt := now.Add(1 * time.Hour)
-		issuedAt := now
-
-		jm.currentToken = &JWTToken{
-			Token:     fallbackToken,
-			ExpiresAt: expiresAt,
-			IssuedAt:  issuedAt,
-			UserID:    jm.userID,
-			LoginID:   jm.loginID,
-		}
-
-		log.Printf("⚠️ Using expired fallback token (will trigger 401)")
-		return fallbackToken, nil
+	jm.consecutiveFailures++
+	if jm.consecutiveFailures >= jm.breakerMaxFailures {
+		jm.breakerOpenUntil = time.Now().Add(jm.breakerOpenDuration)
 	}
-
-	return newToken, nil
 }
 
-// renewToken renews the current token
-func (jm *JWTManager) renewToken() {
-	jm.mutex.Lock()
-	defer jm.mutex.Unlock()
+func (jm *ExternalJWTManager) recordRefreshSuccess() {
+	jm.breakerMu.Lock()
+	defer jm.breakerMu.Unlock()
+	jm.consecutiveFailures = 0
+	jm.breakerOpenUntil = time.Time{}
+}
 
-	// Try to refresh token from API
-	_, err := jm.refreshToken()
-	if err != nil {
-		log.Printf("⚠️ Failed to renew JWT token: %v", err)
-		// Keep the old token if refresh fails
+func (jm *ExternalJWTManager) isCircuitOpen() (bool, time.Duration) {
+	jm.breakerMu.Lock()
+	defer jm.breakerMu.Unlock()
+
+	if jm.breakerOpenUntil.IsZero() {
+		return false, 0
+	}
+	remaining := time.Until(jm.breakerOpenUntil)
+	if remaining <= 0 {
+		jm.breakerOpenUntil = time.Time{}
+		jm.consecutiveFailures = 0
+		return false, 0
+	}
+	return true, remaining
+}
+
+func (jm *ExternalJWTManager) startBackgroundRefresher() {
+	if jm == nil {
 		return
 	}
-
-	log.Printf("🔄 JWT token renewed successfully")
+	jm.backgroundOnce.Do(func() {
+		if jm.backgroundCtx == nil {
+			jm.backgroundCtx, jm.backgroundCancel = context.WithCancel(context.Background())
+		}
+		go jm.backgroundRefreshLoop()
+	})
 }
 
-// generateSessionID generates a random session ID
-func (jm *JWTManager) generateSessionID() string {
-	bytes := make([]byte, 16)
-	rand.Read(bytes)
-	return base64.URLEncoding.EncodeToString(bytes)
-}
+func (jm *ExternalJWTManager) backgroundRefreshLoop() {
+	ticker := time.NewTicker(jm.refreshInterval)
+	defer ticker.Stop()
 
-// GetTokenInfo returns information about the current token
-func (jm *JWTManager) GetTokenInfo() *JWTToken {
-	jm.mutex.RLock()
-	defer jm.mutex.RUnlock()
-	return jm.currentToken
-}
-
-// IsTokenValid checks if the current token is valid
-func (jm *JWTManager) IsTokenValid() bool {
-	jm.mutex.RLock()
-	defer jm.mutex.RUnlock()
-
-	if jm.currentToken == nil {
-		return false
+	for {
+		select {
+		case <-jm.backgroundCtx.Done():
+			return
+		case <-ticker.C:
+			jm.mutex.RLock()
+			current := jm.currentToken
+			renew := current != nil && time.Until(current.ExpiresAt) < jm.renewalTime
+			jm.mutex.RUnlock()
+			if renew {
+				ctx := jm.backgroundCtx
+				if ctx == nil {
+					ctx = context.Background()
+				}
+				refreshCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+				if err := jm.renewTokenWithContext(refreshCtx); err != nil {
+					jm.logRefreshError("background_refresh_failed", err)
+				}
+				cancel()
+			}
+		}
 	}
-
-	return time.Now().Before(jm.currentToken.ExpiresAt)
 }
 
-// ForceRenewal forces token renewal
-func (jm *JWTManager) ForceRenewal() error {
+func (jm *ExternalJWTManager) renewTokenWithContext(ctx context.Context) error {
 	jm.mutex.Lock()
 	defer jm.mutex.Unlock()
 
-	_, err := jm.generateNewToken()
+	_, err := jm.generateNewTokenLocked(ctx)
 	return err
 }
 
-// StartAutoRenewal starts automatic token renewal
-func (jm *JWTManager) StartAutoRenewal() {
-	ticker := time.NewTicker(5 * time.Minute) // Check every 5 minutes
-	defer ticker.Stop()
-
-	log.Println("🔄 JWT Auto-renewal started (checking every 5 minutes)")
-
-	for range ticker.C {
-		jm.mutex.RLock()
-		needsRenewal := jm.currentToken != nil &&
-			time.Until(jm.currentToken.ExpiresAt) < jm.renewalTime
-		jm.mutex.RUnlock()
-
-		if needsRenewal {
-			log.Println("🔄 Auto-renewing JWT token...")
-			jm.renewToken()
-		} else {
-			jm.mutex.RLock()
-			if jm.currentToken != nil {
-				timeUntilExpiry := time.Until(jm.currentToken.ExpiresAt)
-				log.Printf("⏰ JWT token still valid for %v (no renewal needed)", timeUntilExpiry.Round(time.Minute))
-			}
-			jm.mutex.RUnlock()
+func (jm *ExternalJWTManager) triggerAsyncRefresh() {
+	go func() {
+		ctx := jm.backgroundCtx
+		if ctx == nil {
+			ctx = context.Background()
 		}
+		refreshCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+		defer cancel()
+		if err := jm.renewTokenWithContext(refreshCtx); err != nil {
+			jm.logRefreshError("async_refresh_failed", err)
+		}
+	}()
+}
+
+func (jm *ExternalJWTManager) logRefreshError(reason string, err error) {
+	if logger := GetLogger(); logger != nil {
+		fields := []zap.Field{
+			zap.String("reason", reason),
+			zap.Int64("user_id", jm.userID),
+			zap.Int64("login_id", jm.loginID),
+		}
+		if te, ok := err.(*TokenError); ok {
+			fields = append(fields, zap.Int("attempt", te.Attempt))
+			if te.StatusCode > 0 {
+				fields = append(fields, zap.Int("status_code", te.StatusCode))
+			}
+			if te.Cause != nil {
+				fields = append(fields, zap.Error(te.Cause))
+			}
+		} else if err != nil {
+			fields = append(fields, zap.Error(err))
+		}
+		logger.Warn("External JWT refresh error", fields...)
+	}
+	if metrics := GetMetricsCollector(); metrics != nil {
+		metrics.RecordAPIError(metricsServiceExternalJWT, reason)
+	}
+}
+
+func (jm *ExternalJWTManager) GetTokenInfo() *JWTToken {
+	jm.mutex.RLock()
+	defer jm.mutex.RUnlock()
+	if jm.currentToken == nil {
+		return nil
+	}
+	copy := *jm.currentToken
+	return &copy
+}
+
+func (jm *ExternalJWTManager) IsTokenValid() bool {
+	jm.mutex.RLock()
+	defer jm.mutex.RUnlock()
+	return jm.currentToken != nil && time.Now().Before(jm.currentToken.ExpiresAt)
+}
+
+func (jm *ExternalJWTManager) ForceRenewal() error {
+	return jm.renewTokenWithContext(context.Background())
+}
+
+func (jm *ExternalJWTManager) StartAutoRenewal() {
+	jm.startBackgroundRefresher()
+	if logger := GetLogger(); logger != nil {
+		logger.Info("External JWT auto-renewal active", zap.Int64("user_id", jm.userID), zap.Int64("login_id", jm.loginID))
 	}
 }
 
@@ -605,13 +727,20 @@ func InitializeJWTManager() {
 		httpClient,
 	)
 
-	// Generate initial token
-	jwtManager.generateNewToken()
+	if _, err := jwtManager.GetValidToken(); err != nil {
+		if logger := GetLogger(); logger != nil {
+			logger.Error("Failed to prime external JWT token", zap.Error(err))
+		}
+	}
 
-	// Start auto-renewal
 	go jwtManager.StartAutoRenewal()
 
-	log.Println("✅ JWT Manager initialized with auto-renewal")
+	if logger := GetLogger(); logger != nil {
+		logger.Info("JWT Manager initialized with auto-renewal",
+			zap.Int64("user_id", 283617495),
+			zap.Int64("login_id", 605354782),
+		)
+	}
 }
 
 // GetJWTToken returns a valid JWT token
@@ -629,7 +758,9 @@ func GetJWTManager() *JWTManager {
 
 // TestDecodeBody tests the decodeBody function with different content encodings
 func TestDecodeBody() {
-	log.Println("🧪 Testing decodeBody function...")
+	if logger := GetLogger(); logger != nil {
+		logger.Info("Testing decodeBody function")
+	}
 
 	// Test cases for different content encodings
 	testCases := []struct {
@@ -643,10 +774,12 @@ func TestDecodeBody() {
 	}
 
 	for _, tc := range testCases {
-		log.Printf("Testing %s encoding...", tc.name)
-		// Note: This is a simplified test - in real usage, the response body would be properly compressed
-		log.Printf("✅ %s encoding test completed", tc.name)
+		if logger := GetLogger(); logger != nil {
+			logger.Debug("decodeBody test executed", zap.String("encoding", tc.contentEncoding), zap.String("name", tc.name))
+		}
 	}
 
-	log.Println("✅ All decodeBody tests completed")
+	if logger := GetLogger(); logger != nil {
+		logger.Info("decodeBody tests completed")
+	}
 }


### PR DESCRIPTION
## Summary
- replace the Bolt JWT manager with an ExternalJWTManager that adds contextual rate limiting, circuit breaking, and proactive background refresh while using structured logging and metrics hooks
- upgrade the enhanced JWT manager with key rotation grace periods, cached revocation lookups, and reusable revocation checks for analyzers and generators
- unify the JWT generator and analyzer with the enhanced manager, preserving a legacy HS256 path for tests and adding richer token inspection utilities

## Testing
- `go test ./...` *(hangs while fetching dependencies; cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68e6f0c3f2b48325bbc284bd46698618